### PR TITLE
Proof of concept xccdf_eval

### DIFF
--- a/salt/modules/openscap.py
+++ b/salt/modules/openscap.py
@@ -107,3 +107,7 @@ def xccdf(params):
         upload_dir=upload_dir,
         error=error,
         returncode=returncode)
+
+
+def xccdf_eval(profile=None, policy=None):
+    return xccdf('eval --profile {0} {1}'.format(profile, policy))

--- a/tests/unit/modules/openscap_test.py
+++ b/tests/unit/modules/openscap_test.py
@@ -203,3 +203,9 @@ class OpenscapTestCase(TestCase):
                 'returncode': None
             }
         )
+
+    @patch('salt.modules.openscap.xccdf', Mock())
+    def test_openscap_eval(self):
+        response = openscap.xccdf_eval('Default', self.policy_file)
+        openscap.xccdf.assert_called_once_with(
+            'eval --profile Default {0}'.format(self.policy_file))


### PR DESCRIPTION
This is an internal PR in my salt fork: from `myfork/xccdf_eval` branch to `myfork/openscap` branch.

Let's discuss here the implementation of: **openscap.xccdf**

You can see the RFC for the feature is here: https://github.com/SUSE/susemanager-rfc/blob/master/text/00031-salt-openscap-integration.md

If you consider that:
 - this module runs `oscap` command line tool
 - **openscap.xccdf** is like **cmd.run** but restricted to running `oscap xccdf` (1 step less generic than **cmd.run**)
 - you pass a single string parameter to **cmd.run** like this:
  `salt '*' cmd.run 'oscap xccdf eval --profile Defaulat /usr/share/openscap/scap-yast2sec-xccdf.xml'`

It actually makes sense to call **openscap.xccdf** like this:
`salt '*' openscap.xccdf "eval --profile Defaulat /usr/share/openscap/scap-yast2sec-xccdf.xml"`

You would do the same with **cmd.run** but in a more generic way.

The next step down the generic line is **openscap.xccdf_eval**, a even less generic way of running `oscap`:
- `salt '*' openscap.xccdf_eval Default /usr/share/openscap/scap-yast2sec-xccdf.xml`
- `salt '*' openscap.xccdf_eval profile=Default policy=/usr/share/openscap/scap-yast2sec-xccdf.xml`

  The implementation is a one line function and it's in this current PR
